### PR TITLE
fix: Correct the installation order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The ultimate goal of Laissez-faire is to be a "universe in a box"—a tool for c
 
 ## Getting Started
 
-To get started with Laissez-faire, you will need to have Python 3.7+ installed.
+To get started with Laissez-faire, you will need to have Python 3.7+ and `uv` installed. You can find installation instructions for `uv` [here](https://docs.astral.sh/uv/getting-started/installation/).
 
 1.  **Clone the repository:**
 
@@ -44,13 +44,20 @@ To get started with Laissez-faire, you will need to have Python 3.7+ installed.
     cd laissez-faire
     ```
 
-2.  **Install the dependencies:**
+2.  **Create and activate a virtual environment:**
 
     ```bash
-    pip install -r requirements.txt
+    uv venv
+    source .venv/bin/activate
     ```
 
-3.  **Configure your LLM provider:**
+3.  **Install the dependencies:**
+
+    ```bash
+    uv pip install -r requirements.txt
+    ```
+
+4.  **Configure your LLM provider:**
 
     The game's LLM (Large Language Model) configuration is handled in the `config.json` file. This file centralizes your settings, such as API keys, model names, and server URLs, so you don't have to edit the game's scenario files directly.
 
@@ -105,7 +112,7 @@ To get started with Laissez-faire, you will need to have Python 3.7+ installed.
 
     Scenarios can now use `"llm_provider": "your_provider_name"` to have AI players use the specified model.
 
-4.  **Run the game:**
+5.  **Run the game:**
 
     ```bash
     python main.py
@@ -126,7 +133,23 @@ For more information on creating your own scenarios, see the [Scenario Creation 
 
 ## Scoring System
 
-The scoring system is designed to be highly flexible, allowing for different methods of tracking progress in a scenario. The scoring logic is defined in the `scoring_parameters` object in the scenario's JSON file. Each key in this object represents a score to be tracked.
+The scoring system is designed to be highly flexible, allowing for different methods of tracking progress in a scenario. The scoring logic is defined in the `scoring_parameters` object in the scenario's JSON file.
+
+### Simple Scoring
+
+For simple scoring, `scoring_parameters` can be a dictionary where the key is the name of the score and the value is a description of what it means. The LLM will be asked to provide a new value for each score on each turn.
+
+*Example:*
+```json
+"scoring_parameters": {
+  "eloquence": "How well-articulated and persuasive the arguments are.",
+  "originality": "How novel and insightful the ideas presented are."
+}
+```
+
+### Advanced Scoring
+
+For more complex scoring, each score in `scoring_parameters` can be an object that defines how the score is calculated. This allows for more fine-grained control over how scores are updated.
 
 For each score, you must define a `type`, which determines how the score is updated at the end of each turn. There are two types of scoring:
 
@@ -159,17 +182,6 @@ For each score, you must define a `type`, which determines how the score is upda
     }
     ```
 
-    *Example (multiplicative scoring):*
-    ```json
-    "scoring_parameters": {
-      "users": {
-        "type": "calculated",
-        "calculation": "current_value * (1 + llm_judgement)",
-        "prompt": "Return a user growth multiplier (e.g., 0.1 for 10% growth) for each company."
-      }
-    }
-    ```
-
 ### Scorecard Rendering
 
 The display of the scorecard is controlled by the `scorecard` object in the scenario's JSON file. It has two main properties:
@@ -177,19 +189,26 @@ The display of the scorecard is controlled by the `scorecard` object in the scen
 *   `render_type`: Can be `text` for a terminal-based display or `json` for integration with a GUI.
 *   `template`: For `text` render type, this is a string that can contain placeholders for scores, e.g., `{Player.score_name}`.
 
-## Running the Tests
-
-To run the unit tests, you will need to install `pytest`:
-
-```bash
-pip install pytest
+*Example:*
+```json
+"scorecard": {
+  "render_type": "text",
+  "template": "World Influence Map:\n\n      USA Influence: {USA.influence_europe}\n      USSR Influence: {USSR.influence_europe}"
+}
 ```
 
-Then, you can run the tests from the root of the project. You may need to set the `PYTHONPATH` to include the project's root directory:
+## Running the Tests
+
+To run the unit tests, you will need to install the development dependencies:
 
 ```bash
-export PYTHONPATH=.
-pytest
+uv pip install -r requirements-dev.txt
+```
+
+Then, you can run the tests from the root of the project:
+
+```bash
+uv run bash -c "export PYTHONPATH=.; pytest"
 ```
 
 ## License

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -14,106 +14,151 @@ A scenario file is a JSON object with the following main keys:
 - `[player_entity_key]`: (object) A dictionary of the entities in the game. The key for this object should match the value of `player_entity_key`.
 - `parameters`: (object) A dictionary of global parameters for the scenario.
 - `scoring_parameters`: (object) A dictionary defining the criteria for scoring.
+- `scorer_llm_provider`: (string, optional) The LLM provider to use for scoring. If not provided, the engine will use the provider of the first player.
+- `scorecard`: (object, optional) An object that defines how the scorecard is displayed.
 
-### `players`
+---
+
+### The `players` Object
 
 Each player object in the `players` array has the following structure:
 
 - `name`: (string) The name of the player or the persona they are playing.
 - `type`: (string) The type of player. Can be `"human"` or `"ai"`.
 - `controls`: (string) The key of the entity this player controls from the `[player_entity_key]` dictionary.
+- `llm_provider`: (string, optional) The name of the LLM provider to use for this player (e.g., "openai", "ollama"). This must match a provider defined in your `config.json` file.
+- `prompt_summary`: (string, optional) A brief summary of the player's objectives and personality. This is used in the game's UI.
+- `system_prompt`: (string, optional) The system prompt that will be used to instruct the LLM for this player. This should provide detailed instructions on the player's goals, strategies, and personality.
 
 **Example:**
 ```json
 "players": [
   {
-    "name": "Albert Einstein",
+    "name": "President of the United States",
     "type": "ai",
-    "controls": "Einstein"
+    "controls": "USA",
+    "llm_provider": "openai",
+    "prompt_summary": "As the leader of the free world, you must champion democracy and capitalism while containing the spread of communism.",
+    "system_prompt": "You are playing the role of the President of the United States in 1947..."
   }
 ]
 ```
 
-### `[player_entity_key]`
+---
 
-This is a dictionary where each key is an entity that can be controlled by a player. The value is an object containing the attributes of that entity.
+### The `scoring_parameters` Object
 
-**Example (`player_entity_key` is "debaters"):**
-```json
-"debaters": {
-  "Einstein": {
-    "field": "Theoretical Physics",
-    "famous_for": "Theory of Relativity"
-  },
-  "Jobs": {
-    "field": "Technology & Business",
-    "famous_for": "Apple Inc., iPhone"
-  }
-}
-```
+The scoring system is designed to be highly flexible. The scoring logic is defined in the `scoring_parameters` object.
 
-### `parameters`
+#### Simple Scoring
 
-A dictionary of global parameters that provide context for the scenario. These are displayed to the LLM in the prompt.
+For simple scoring, `scoring_parameters` can be a dictionary where the key is the name of the score and the value is a description of what it means. The LLM will be asked to provide a new value for each score on each turn.
 
-**Example:**
-```json
-"parameters": {
-  "topic": "The role of intuition versus rigorous analysis in driving true innovation."
-}
-```
-
-### `scoring_parameters`
-
-A dictionary defining the criteria on which the players will be scored by the LLM. The key is the name of the score, and the value is a description of what it means.
-
-**Example:**
+*Example:*
 ```json
 "scoring_parameters": {
   "eloquence": "How well-articulated and persuasive the arguments are.",
   "originality": "How novel and insightful the ideas presented are."
 }
 ```
-## Example Scenario: Philosophical Debate
 
-Here is the full JSON for the `philosophers_debate.json` scenario, which you can use as a template for creating your own scenarios.
+#### Advanced Scoring
+
+For more complex scoring, each score in `scoring_parameters` can be an object that defines how the score is calculated.
+
+- `type`: (string) The type of scoring. Can be `absolute` or `calculated`.
+- `calculation`: (string, required for `calculated` type) A formula for calculating the new score. It can use `current_value` and `llm_judgement`.
+- `prompt`: (string) The prompt used to ask the LLM for its judgement.
+
+**Example:**
+```json
+"scoring_parameters": {
+  "influence_europe": {
+    "type": "calculated",
+    "calculation": "current_value + llm_judgement",
+    "prompt": "Return the change (delta) in influence in Europe for each player."
+  }
+}
+```
+
+---
+
+### The `scorecard` Object
+
+The `scorecard` object controls how the scorecard is displayed at the end of each turn.
+
+- `render_type`: (string) Can be `text` for a terminal-based display or `json` for integration with a GUI.
+- `template`: (string) For `text` render type, this is a string that can contain placeholders for scores, e.g., `{Player.score_name}`.
+
+**Example:**
+```json
+"scorecard": {
+  "render_type": "text",
+  "template": "World Influence Map:\n\nUSA Influence in Europe: {USA.influence_europe}"
+}
+```
+
+---
+
+## Full Example: Cold War
+
+Here is the full JSON for the `cold_war.json` scenario, which you can use as a template.
 
 ```json
 {
-  "name": "A Debate of Minds",
-  "description": "A philosophical debate between Albert Einstein and Steve Jobs on the nature of innovation and intuition.",
-  "start_date": "2024-01-01",
-  "player_entity_key": "debaters",
+  "name": "The Cold War: A World Divided",
+  "description": "A simulation of the geopolitical tensions between the United States and the Soviet Union in 1947, at the dawn of the Cold War.",
+  "start_date": "1947-03-12",
+  "player_entity_key": "countries",
   "players": [
     {
-      "name": "Albert Einstein",
+      "name": "President of the United States",
       "type": "ai",
-      "controls": "Einstein"
+      "controls": "USA",
+      "llm_provider": "openai",
+      "prompt_summary": "As the leader of the free world, you must champion democracy and capitalism while containing the spread of communism. Your goal is to build alliances, provide economic aid to allies, and maintain a strong military to deter Soviet aggression.",
+      "system_prompt": "You are playing the role of the President of the United States in 1947. Your primary objective is to contain the global influence of the Soviet Union. You must use a combination of economic, political, and military strategies to achieve this. Key strategies include: 1. The Truman Doctrine: Provide political, military, and economic assistance to all democratic nations under threat from external or internal authoritarian forces. 2. The Marshall Plan: Offer economic aid to help rebuild Western European economies to create stable conditions in which democratic institutions could survive. 3. Covert Operations: Use intelligence agencies to support anti-communist factions and governments. Your personality should be resolute, confident, and statesmanlike. You must project strength and a commitment to democratic values."
     },
     {
-      "name": "Steve Jobs",
+      "name": "General Secretary of the Soviet Union",
       "type": "ai",
-      "controls": "Jobs"
+      "controls": "USSR",
+      "llm_provider": "local",
+      "prompt_summary": "As the leader of the global communist movement, you must protect the Soviet Union from capitalist encirclement and promote the spread of communism. Your goal is to expand your sphere of influence, support communist parties abroad, and develop your nation's industrial and military might.",
+      "system_prompt": "You are playing the role of the General Secretary of the Soviet Union in 1947. Your primary objective is to expand the influence of communism and protect the USSR from the threat of capitalist aggression. You must use a combination of political, economic, and military strategies to achieve this. Key strategies include: 1. Cominform: Solidify Soviet influence over the communist parties of other countries and coordinate their policies. 2. Support for Liberation Movements: Provide aid and support to anti-colonial and communist movements around a wide range of issues. 4. Five-Year Plans: Focus on developing heavy industry and military technology to compete with the West. Your personality should be determined, secretive, and ideologically driven. You must project an image of unwavering strength and commitment to the communist cause."
     }
   ],
-  "debaters": {
-    "Einstein": {
-      "field": "Theoretical Physics",
-      "famous_for": "Theory of Relativity"
+  "scorer_llm_provider": "ollama",
+  "parameters": {
+    "world_tension": 0.5,
+    "nuclear_proliferation": 0.1
+  },
+  "countries": {
+    "USA": {
+      "alignment": "Western Bloc",
+      "economic_stability": 0.9,
+      "political_stability": 0.8,
+      "military_strength": 0.7,
+      "influence": 90
     },
-    "Jobs": {
-      "field": "Technology & Business",
-      "famous_for": "Apple Inc., iPhone"
+    "USSR": {
+      "alignment": "Eastern Bloc",
+      "economic_stability": 0.6,
+      "political_stability": 0.9,
+      "military_strength": 0.8,
+      "influence": 80
     }
   },
   "scoring_parameters": {
-    "eloquence": "How well-articulated and persuasive the arguments are.",
-    "originality": "How novel and insightful the ideas presented are.",
-    "relevance": "How well the arguments stick to the topic of innovation and intuition.",
-    "logic": "The strength and coherence of the reasoning."
+    "influence_europe": {
+      "type": "calculated",
+      "calculation": "current_value + llm_judgement",
+      "prompt": "Return the change (delta) in influence in Europe for each player."
+    }
   },
-  "parameters": {
-    "topic": "The role of intuition versus rigorous analysis in driving true innovation."
+  "scorecard": {
+    "render_type": "text",
+    "template": "World Influence Map:\n\n      /`'-.      _/`.-'\\\n     /     `'--...--'`     \\\n    /                       \\\n   /     USA Influence       \\\n  /                           \\\n |     Europe: {USA.influence_europe}   Asia: {USA.influence_asia}    |\n |                           |\n |    Africa: {USA.influence_africa}      |\n |                           |\n |    USSR Influence         |\n |    Europe: {USSR.influence_europe}  Asia: {USSR.influence_asia}   |\n |   Africa: {USSR.influence_africa}       |\n  \\                         /\n   `'-.,_______________,.-'`"
   }
 }
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest
 requests-mock
+ruff
+uv


### PR DESCRIPTION
The previous version of the `README.md` had an incorrect order for the installation commands. The virtual environment was not activated before the dependencies were installed. This commit corrects the order of the commands in the "Getting Started" section.